### PR TITLE
Trigger action with title, not label

### DIFF
--- a/.github/ISSUE_TEMPLATE/delete.md
+++ b/.github/ISSUE_TEMPLATE/delete.md
@@ -2,7 +2,6 @@
 name: 🔴 Delete a package
 about: Use this template for deleting an existing package of your PyPi index.
 title: "🔴 Delete package :"
-labels: delete-package
 ---
 
 ## 🔴 Package deletion form

--- a/.github/ISSUE_TEMPLATE/register.md
+++ b/.github/ISSUE_TEMPLATE/register.md
@@ -2,7 +2,6 @@
 name: 🟢 Register a new package
 about: Use this template for registering a new package in your PyPi index.
 title: "🟢 New package :"
-labels: register-package
 ---
 
 ## 🟢 New package registration form

--- a/.github/ISSUE_TEMPLATE/update.md
+++ b/.github/ISSUE_TEMPLATE/update.md
@@ -2,7 +2,6 @@
 name: 🔵 Update a package
 about: Use this template for adding a new version of an existing package in your PyPi index.
 title: "🔵 Update package :"
-labels: update-package
 ---
 
 ## 🔵 Package update form

--- a/.github/actions.py
+++ b/.github/actions.py
@@ -167,16 +167,15 @@ def main():
     # Get the context from the environment variable
     context = json.loads(os.environ['GITHUB_CONTEXT'])
     issue_ctx = context['event']['issue']
+    title = issue_ctx['title']
 
-    labels = [label['name'] for label in issue_ctx['labels']]
-
-    if 'register-package' in labels:
+    if title.startswith("🟢"):
         register(issue_ctx)
 
-    if 'update-package' in labels:
+    if title.startswith("🔵"):
         update(issue_ctx)
 
-    if 'delete-package' in labels:
+    if title.startswith("🔴"):
         delete(issue_ctx)
 
 

--- a/.github/workflows/register_update.yml
+++ b/.github/workflows/register_update.yml
@@ -2,7 +2,7 @@ name: register_update
 
 on:
   issues:
-    types: [labeled]
+    types: [opened, edited]
 
 jobs:
   build:


### PR DESCRIPTION
Fix #29 

---

Because cloning the template does not clone automatically the labels as well, github actions does not work out of the box.

So we change it to make it work based on the title, not labels.