### PR TITLE
Fix version comparison

### DIFF
--- a/static/package_page.js
+++ b/static/package_page.js
@@ -32,6 +32,20 @@ function load_readme(version, scroll_to_div=false){
   });
 }
 
+function put_readme(version, markupContent, scroll_to_div=false){
+  addDynamicClickDelegation(`${version}`);
+
+  const contentDivs = document.querySelectorAll('.versions div');
+  contentDivs.forEach(div => div.classList.remove('selected'));
+
+  document.getElementById(version).classList.add('selected');
+  document.getElementById('markdown-container').innerHTML = marked.parse(markupContent);
+  if (scroll_to_div) {
+    // document.getElementById('description_pkg').scrollIntoView();
+    history.replaceState(null, null, '#'+version);
+  }
+}
+
 function warn_unsafe() {
   document.getElementById('installdanger').hidden = false;
   document.getElementById('installcmd').hidden = true;

--- a/static/pypi_checker.js
+++ b/static/pypi_checker.js
@@ -1,4 +1,10 @@
 function semverCompare(a, b) {
+    // Remove leading letters, such as `v` (`v4.23` becomes `4.23`)
+    const clean = (v) => v.replace(/^[a-zA-Z]+/, "");
+    a = clean(a);
+    b = clean(b);
+
+    // Actual comparison
     if (a.startsWith(b + "-")) return -1
     if (b.startsWith(a + "-")) return  1
     return a.localeCompare(b, undefined, { numeric: true, sensitivity: "case", caseFirst: "upper" })

--- a/transformers/index.html
+++ b/transformers/index.html
@@ -98,20 +98,12 @@
   </div>
   
   <script>
-    var url_readme_main = 'https://raw.githubusercontent.com/huggingface/transformers/main/README.md';
-    
     $(document).ready(function () {
       var this_vers = document.getElementById('latest-main-version').textContent.trim();
       document.getElementById(this_vers).classList.add('main');
       check_supply_chain_attack("transformers", this_vers, warn_unsafe);
-    
-      if (window.location.hash != "") {
-        let version_hash = window.location.hash;
-        version = version_hash.replace('#', '');
-        load_readme(version, scroll_to_div=true);
-        return;
-      }
-      load_readme(this_vers);
+
+      put_readme(this_vers, "This is a (safe) example of a package vulnerable to supply chain attacks. Here we registered a private package called `transformers`. But another package with the exact same name and a higher version is registered in the public PyPi index. Running the install command would install the package registered there (which might be malicious), not my private package as intended. If that's the case, a warning is displayed in this page.");
     });
   </script>
 </body>


### PR DESCRIPTION
Version comparison wasn't working properly when the version has a prefix (like `v3.45` vs `3.46`).

This PR fixes that.

---

It also remove the README from `transformers` package, and instead uses a custom README that explains the potential vulnerability.